### PR TITLE
Moved test_util package to avoid name clash

### DIFF
--- a/src/test/scala/FSmooth/typeInference.scala
+++ b/src/test/scala/FSmooth/typeInference.scala
@@ -3,7 +3,7 @@ package FSmooth
 import FSmooth.DSL._
 import FSmooth.MSmooth._
 
-class typeInference extends test_util.Tests {
+class typeInference extends elevate.test_util.Tests {
 
   test("Type inference MSmooth vector constructs") {
     println("vectorRange = " + TypeInference.infer(vectorRange))

--- a/src/test/scala/elevate/fsmooth/rewriteExamples.scala
+++ b/src/test/scala/elevate/fsmooth/rewriteExamples.scala
@@ -8,7 +8,7 @@ import elevate.core.strategies.traversal.oncetd
 import elevate.fsmooth.rules._
 import elevate.fsmooth.traversal._
 
-class rewriteExamples extends test_util.Tests {
+class rewriteExamples extends elevate.test_util.Tests {
 
   test("Example5: Matrix Transpose") {
     val e = fun(M => matrixTranspose(matrixTranspose(M)))

--- a/src/test/scala/elevate/rise/fissionFusion.scala
+++ b/src/test/scala/elevate/rise/fissionFusion.scala
@@ -12,7 +12,7 @@ import rise.core._
 import elevate.util._
 
 
-class fissionFusion extends test_util.Tests {
+class fissionFusion extends elevate.test_util.Tests {
 
   def eq(a: Expr, b: Expr): Unit = {
     if (BENF(a).get != BENF(b).get) {

--- a/src/test/scala/elevate/rise/fmap.scala
+++ b/src/test/scala/elevate/rise/fmap.scala
@@ -8,7 +8,7 @@ import elevate.rise.strategies.traversal._
 import elevate.util._
 import rise.core.TypedDSL._
 
-class fmap extends test_util.Tests {
+class fmap extends elevate.test_util.Tests {
 
   test("fmap basic level0") {
     assert(betaEtaEquals(

--- a/src/test/scala/elevate/rise/halide.scala
+++ b/src/test/scala/elevate/rise/halide.scala
@@ -8,7 +8,7 @@ import elevate.rise.strategies.normalForm._
 import elevate.util._
 import rise.core.TypedDSL.{reorder => _, _}
 
-class halide extends test_util.Tests {
+class halide extends elevate.test_util.Tests {
   private def LCNFrewrite(a: Rise, s: Strategy[Rise], b: Rise): Unit = {
     val (closedA, nA) = makeClosed(a)
     val (closedB, nB) = makeClosed(b)

--- a/src/test/scala/elevate/rise/movement.scala
+++ b/src/test/scala/elevate/rise/movement.scala
@@ -11,7 +11,7 @@ import rise.core.TypedDSL._
 import rise.core.TypeLevelDSL._
 import rise.core.types.f32
 
-class movement extends test_util.Tests {
+class movement extends elevate.test_util.Tests {
 
   // transpose
 

--- a/src/test/scala/elevate/rise/traversals.scala
+++ b/src/test/scala/elevate/rise/traversals.scala
@@ -16,7 +16,7 @@ import rise.core.types.NatKind
 import rise.core.primitives._
 
 
-class traversals extends test_util.Tests {
+class traversals extends elevate.test_util.Tests {
 
   test("rewrite simple elevate strategy") {
     val expr = fun(f => fun(g => map(f) >> map(g)))

--- a/src/test/scala/elevate/test_util/package.scala
+++ b/src/test/scala/elevate/test_util/package.scala
@@ -1,3 +1,5 @@
+package elevate
+
 import com.github.ghik.silencer.silent
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers


### PR DESCRIPTION
This change avoids confusion :stop_sign: :confused: which `test_util.Test` should be used by which tests.

There are corresponding pull requests in the rise and shine repos as well.