### PR TITLE
Add Cases for Traversal of DepLambda

### DIFF
--- a/src/main/scala/elevate/rise/rules/package.scala
+++ b/src/main/scala/elevate/rise/rules/package.scala
@@ -15,9 +15,25 @@ package object rules {
         case lifting.Reducing(lf) => Success(lf(x) :: e.t)
         case _                    => Failure(betaReduction)
       }
-      case DepApp(f, x: Nat) => typedLifting.liftDepFunExpr[NatKind](f) match {
-        case lifting.Reducing(lf) => Success(lf(x) :: e.t)
+      case DepApp(f, n: Nat) => typedLifting.liftDepFunExpr[NatKind](f) match {
+        case lifting.Reducing(lf) => Success(lf(n) :: e.t)
         case _                    => Failure(betaReduction)
+      }
+      case DepApp(f, dt: DataType) => typedLifting.liftDepFunExpr[DataKind](f) match {
+        case lifting.Reducing(lf) => Success(lf(dt) :: e.t)
+        case _                    => Failure(betaReduction)
+      }
+      case DepApp(f, addr: AddressSpace) => typedLifting.liftDepFunExpr[AddressSpaceKind](f) match {
+        case lifting.Reducing(lf) => Success(lf(addr) :: e.t)
+        case _ => Failure(betaReduction)
+      }
+      case DepApp(f, n2n: NatToNat) => typedLifting.liftDepFunExpr[NatToNatKind](f) match {
+        case lifting.Reducing(lf) => Success(lf(n2n) :: e.t)
+        case _ => Failure(betaReduction)
+      }
+      case DepApp(f, n2d: NatToData) => typedLifting.liftDepFunExpr[NatToDataKind](f) match {
+        case lifting.Reducing(lf) => Success(lf(n2d) :: e.t)
+        case _ => Failure(betaReduction)
       }
       case _                      => Failure(betaReduction)
     }

--- a/src/main/scala/elevate/rise/rules/traversal.scala
+++ b/src/main/scala/elevate/rise/rules/traversal.scala
@@ -9,41 +9,54 @@ import rise.core.types._
 
 object traversal {
 
-  // Handle all Rise-AST nodes that contain one or no subexpressions (all except App)
-  private def traverseSingleSubexpression: Strategy[Rise] => Rise => Option[RewriteResult[Rise]] =
+  // Handle all Rise-AST nodes that contain one
+  // or no subexpressions (all except App)
+  type TraversalType = Strategy[Rise] => Rise => Option[RewriteResult[Rise]]
+  private def traverseSingleSubexpression: TraversalType =
     s => {
-      case App(_,_)                       => throw new Exception("this should not happen")
-      case Identifier(_)                  => None
-      case l @ Lambda(x, e)               => Some(s(e).mapSuccess(Lambda(x, _)(l.t)))
-      case dl @ DepLambda(x, e)           => x match {
-        case n: NatIdentifier             => Some(s(e).mapSuccess(DepLambda[NatKind](n, _)(dl.t)))
-        case dt: DataTypeIdentifier       => Some(s(e).mapSuccess(DepLambda[DataKind](dt, _)(dl.t)))
-        case addr: AddressSpaceIdentifier => Some(s(e).mapSuccess(DepLambda[AddressSpaceKind](addr, _)(dl.t)))
+      case App(_,_) => throw new Exception("this should not happen")
+      case Identifier(_) => None
+      case l @ Lambda(x, e) => Some(s(e).mapSuccess(Lambda(x, _)(l.t)))
+      case dl @ DepLambda(x, e) => x match {
+        case n: NatIdentifier =>
+          Some(s(e).mapSuccess(DepLambda[NatKind](n, _)(dl.t)))
+        case dt: DataTypeIdentifier =>
+          Some(s(e).mapSuccess(DepLambda[DataKind](dt, _)(dl.t)))
+        case addr: AddressSpaceIdentifier =>
+          Some(s(e).mapSuccess(DepLambda[AddressSpaceKind](addr, _)(dl.t)))
       }
-      case da @ DepApp(f, x)        => x match {
-        case n: Nat                 => Some(s(f).mapSuccess(DepApp[NatKind](_, n)(da.t)))
-        case dt: DataType           => Some(s(f).mapSuccess(DepApp[DataKind](_, dt)(da.t)))
-        case addr: AddressSpace     => Some(s(f).mapSuccess(DepApp[AddressSpaceKind](_, addr)(da.t)))
+      case da @ DepApp(f, x)=> x match {
+        case n: Nat => Some(s(f).mapSuccess(DepApp[NatKind](_, n)(da.t)))
+        case dt: DataType =>
+          Some(s(f).mapSuccess(DepApp[DataKind](_, dt)(da.t)))
+        case addr: AddressSpace =>
+          Some(s(f).mapSuccess(DepApp[AddressSpaceKind](_, addr)(da.t)))
       }
-      case Literal(_)               => None
-      case _: ForeignFunction       => None
-      case _: Primitive             => None
+      case Literal(_) => None
+      case _: ForeignFunction => None
+      case _: Primitive => None
     }
 
   // For Rise, the only AST node that contains multiple subexpressions is App!
-  implicit object LiftTraversable extends elevate.core.strategies.Traversable[Rise] {
-    override def all: Strategy[Rise] => Strategy[Rise] = s => {
-      case ap @ App(f, e) => s(f).flatMapSuccess(a => s(e).mapSuccess(b => App(a, b)(ap.t)))
+  implicit object LiftTraversable
+    extends elevate.core.strategies.Traversable[Rise] {
 
-      // Push s further down the AST. If there are no subexpressions (None), we're done
+    override def all: Strategy[Rise] => Strategy[Rise] = s => {
+      case ap @ App(f, e) =>
+        s(f).flatMapSuccess(a => s(e).mapSuccess(b => App(a, b)(ap.t)))
+
+      // Push s further down the AST.
+      // If there are no subexpressions (None), we're done
       case x => traverseSingleSubexpression(s)(x) match {
         case Some(r) => r
         case None => Success(x)
       }
     }
 
-  override def one: Strategy[Rise] => Strategy[Rise] = oneHandlingState(false)
-  override def oneUsingState: Strategy[Rise] => Strategy[Rise] = oneHandlingState(true)
+  override def one: Strategy[Rise] => Strategy[Rise] =
+    oneHandlingState(false)
+  override def oneUsingState: Strategy[Rise] => Strategy[Rise] =
+    oneHandlingState(true)
 
   private def oneHandlingState: Boolean => Strategy[Rise] => Strategy[Rise] =
       carryOverState => s => {
@@ -54,7 +67,9 @@ object traversal {
                 s(e).mapSuccess(App(f, _)(a.t))
         }
 
-        // Push s further down the AST. If there are no subexpressions (None), we failed to apply s once => Failure
+        // Push s further down the AST.
+        // If there are no subexpressions (None),
+        // we failed to apply s once => Failure
         case x => traverseSingleSubexpression(s)(x) match {
           case Some(r) => r
           case None    => Failure(s)
@@ -64,7 +79,8 @@ object traversal {
     override def some: Strategy[Rise] => Strategy[Rise] = s => {
       case a @ App(f, e) => (s(f), s(e)) match {
         case (Failure(_), Failure(_)) => Failure(s)
-        case (x, y)                   => Success(App(x.getProgramOrElse(f), y.getProgramOrElse(e))(a.t))
+        case (x, y) =>
+          Success(App(x.getProgramOrElse(f), y.getProgramOrElse(e))(a.t))
       }
 
       // ...same here (see oneHandlingState)
@@ -79,13 +95,18 @@ object traversal {
 
   case class body(s: Strategy[Rise]) extends Strategy[Rise] {
     def apply(e: Rise): RewriteResult[Rise] = e match {
-      case Lambda(x, f)                            => s(f).mapSuccess(Lambda(x, _)(e.t))
-      case DepLambda(x: NatIdentifier, f)          => s(f).mapSuccess(DepLambda[NatKind](x, _)(e.t))
-      case DepLambda(x: DataTypeIdentifier, f)     => s(f).mapSuccess(DepLambda[DataKind](x, _)(e.t))
-      case DepLambda(x: AddressSpaceIdentifier, f) => s(f).mapSuccess(DepLambda[AddressSpaceKind](x, _)(e.t))
-      case DepLambda(x: NatToNatIdentifier, f)     => s(f).mapSuccess(DepLambda[NatToNatKind](x, _)(e.t))
-      case DepLambda(x: NatToDataIdentifier, f)    => s(f).mapSuccess(DepLambda[NatToDataKind](x, _)(e.t))
-      case _                                       => Failure(s)
+      case Lambda(x, f) => s(f).mapSuccess(Lambda(x, _)(e.t))
+      case DepLambda(x: NatIdentifier, f) =>
+        s(f).mapSuccess(DepLambda[NatKind](x, _)(e.t))
+      case DepLambda(x: DataTypeIdentifier, f) =>
+        s(f).mapSuccess(DepLambda[DataKind](x, _)(e.t))
+      case DepLambda(x: AddressSpaceIdentifier, f) =>
+        s(f).mapSuccess(DepLambda[AddressSpaceKind](x, _)(e.t))
+      case DepLambda(x: NatToNatIdentifier, f) =>
+        s(f).mapSuccess(DepLambda[NatToNatKind](x, _)(e.t))
+      case DepLambda(x: NatToDataIdentifier, f) =>
+        s(f).mapSuccess(DepLambda[NatToDataKind](x, _)(e.t))
+      case _ => Failure(s)
     }
     override def toString = s"body($s)"
   }
@@ -93,7 +114,7 @@ object traversal {
   case class function(s: Strategy[Rise]) extends Strategy[Rise] {
     def apply(e: Rise): RewriteResult[Rise] = e match {
       case ap @ App(f, x) => s(f).mapSuccess(App(_, x)(ap.t))
-      case _              => Failure(s)
+      case _ => Failure(s)
     }
     override def toString = s"function($s)"
   }
@@ -101,15 +122,17 @@ object traversal {
  case class argument(s: Strategy[Rise]) extends Strategy[Rise] {
     def apply(e: Rise): RewriteResult[Rise] = e match {
       case ap @ App(f, x) => s(x).mapSuccess(App(f, _)(ap.t))
-      case _              => Failure(s)
+      case _ => Failure(s)
     }
     override def toString = s"argument($s)"
   }
 
-  case class argumentOf(p: Primitive, s: Strategy[Rise]) extends Strategy[Rise] {
+  case class argumentOf(p: Primitive, s: Strategy[Rise])
+    extends Strategy[Rise] {
+
     def apply(e: Rise): RewriteResult[Rise] = e match {
       case ap @ App(f, x) if f == p => s(x).mapSuccess(App(f, _)(ap.t))
-      case _                        => Failure(s)
+      case _ => Failure(s)
     }
     override def toString = s"argumentOf($p,$s)"
   }

--- a/src/main/scala/elevate/rise/rules/traversal.scala
+++ b/src/main/scala/elevate/rise/rules/traversal.scala
@@ -12,16 +12,18 @@ object traversal {
   // Handle all Rise-AST nodes that contain one or no subexpressions (all except App)
   private def traverseSingleSubexpression: Strategy[Rise] => Rise => Option[RewriteResult[Rise]] =
     s => {
-      case App(_,_)                 => throw new Exception("this should not happen")
-      case Identifier(_)            => None
-      case l @ Lambda(x, e)         => Some(s(e).mapSuccess(Lambda(x, _)(l.t)))
-      case dl @ DepLambda(x, e)     => x match {
-        case n: NatIdentifier       => Some(s(e).mapSuccess(DepLambda[NatKind](n, _)(dl.t)))
-        case dt: DataTypeIdentifier => Some(s(e).mapSuccess(DepLambda[DataKind](dt, _)(dl.t)))
+      case App(_,_)                       => throw new Exception("this should not happen")
+      case Identifier(_)                  => None
+      case l @ Lambda(x, e)               => Some(s(e).mapSuccess(Lambda(x, _)(l.t)))
+      case dl @ DepLambda(x, e)           => x match {
+        case n: NatIdentifier             => Some(s(e).mapSuccess(DepLambda[NatKind](n, _)(dl.t)))
+        case dt: DataTypeIdentifier       => Some(s(e).mapSuccess(DepLambda[DataKind](dt, _)(dl.t)))
+        case addr: AddressSpaceIdentifier => Some(s(e).mapSuccess(DepLambda[AddressSpaceKind](addr, _)(dl.t)))
       }
       case da @ DepApp(f, x)        => x match {
         case n: Nat                 => Some(s(f).mapSuccess(DepApp[NatKind](_, n)(da.t)))
         case dt: DataType           => Some(s(f).mapSuccess(DepApp[DataKind](_, dt)(da.t)))
+        case addr: AddressSpace     => Some(s(f).mapSuccess(DepApp[AddressSpaceKind](_, addr)(da.t)))
       }
       case Literal(_)               => None
       case _: ForeignFunction       => None


### PR DESCRIPTION
Add cases to beta-reduce `DepApp` of kinds other than `Nat`.

Add a case to enable traversing `DepLambda` of `AddressSpaceKind`.